### PR TITLE
Refactor API to ease ROSDiscover integration

### DIFF
--- a/src/roswire/ros1/ros1.py
+++ b/src/roswire/ros1/ros1.py
@@ -81,6 +81,8 @@ class ROS1:
         self.__uri = f"http://{ip_address}:{port}"
         self.__connection: Optional[xmlrpc.client.ServerProxy] = None
         self.__roscore_process: Optional[dockerblade.popen.Popen] = None
+        self.__package_source_extractor = \
+            ROS1PackageSourceExtractor.for_filesystem(self.__files)
 
     def __enter__(self) -> "ROS1":
         """
@@ -426,7 +428,6 @@ class ROS1:
             A (possibly empty) mapping between node names provided by the
             package and their source information
         """
-        self.must_be_connected()
         return self.__package_source_extractor.get_cmake_info(
             package
         ).targets

--- a/src/roswire/ros1/source.py
+++ b/src/roswire/ros1/source.py
@@ -5,6 +5,7 @@ import os.path
 import typing as t
 
 import attr
+import dockerblade
 from loguru import logger
 
 from ..common import Package
@@ -23,6 +24,13 @@ class ROS1PackageSourceExtractor(CMakeExtractor):
         app_instance: "AppInstance",
     ) -> "ROS1PackageSourceExtractor":
         return ROS1PackageSourceExtractor(files=app_instance.files)
+
+    @classmethod
+    def for_filesystem(
+        cls,
+        files: dockerblade.FileSystem
+    ) -> "ROS1PackageSourceExtractor":
+        return ROS1PackageSourceExtractor(files)
 
     def get_cmake_info(
         self,

--- a/src/roswire/ros1/source.py
+++ b/src/roswire/ros1/source.py
@@ -47,7 +47,8 @@ class ROS1PackageSourceExtractor(CMakeExtractor):
         nodelets = self.get_nodelet_entrypoints(package)
         for nodelet, entrypoint in nodelets.items():
             if nodelet not in info.targets:
-                logger.error(f"'{nodelet}' is referenced in "
+                logger.error(f"Package {package.name}: '{nodelet}' "
+                             f"is referenced in "
                              f"nodelet_plugins.xml but not in "
                              f"CMakeLists.txt")
             else:


### PR DESCRIPTION
This changes the API so that an app_instance is not required. (There is a connection to ROS already established in ROS2 but not in ROS1 of `App`.) The cmake parsing only requires `dockerblade.FileSystem` so we use that to build the CMakeParser.