### PR TITLE
Make cmake commands case sensitive

### DIFF
--- a/src/roswire/common/source.py
+++ b/src/roswire/common/source.py
@@ -168,7 +168,7 @@ class CMakeExtractor(abc.ABC):
         executables: t.Dict[str, CMakeTarget] = {}
         context = ParserContext().parse(file_contents, skip_callable=False)
         for cmd, args, _arg_tokens, (_fname, _line, _column) in context:
-            logger.info(f"-----------> CMake processing command: {cmd} ({args})")
+            cmd = cmd.lower()
             if cmd == "set":
                 opts, args = cmake_argparse(
                     args,

--- a/src/roswire/common/source.py
+++ b/src/roswire/common/source.py
@@ -168,6 +168,7 @@ class CMakeExtractor(abc.ABC):
         executables: t.Dict[str, CMakeTarget] = {}
         context = ParserContext().parse(file_contents, skip_callable=False)
         for cmd, args, _arg_tokens, (_fname, _line, _column) in context:
+            logger.info(f"-----------> CMake processing command: {cmd} ({args})")
             if cmd == "set":
                 opts, args = cmake_argparse(
                     args,


### PR DESCRIPTION
The parser was not recognizing ADD_EXECUTABLE and add_executable as the same thing. This is fixed, and addresses: https://github.com/rosqual/rosdiscover/issues/184