### PR TITLE
Added cmake_targets_for_all_packages for ROS1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -87,7 +87,9 @@ commands =
 ignore_missing_imports = False
 disallow_untyped_defs = True
 warn_unused_ignores = True
-exclude = roswire/common/cmake.py
+
+[mypy-roswire.common.cmake]
+ignore_errors = True
 
 [mypy-docker.*]
 ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ addopts = -rx -v
 
 [flake8]
 ignore = E203, W605, D100, D101, D102, D103, D104, D105, D107, D205, D400, D401, D404, D405
-max-line-length = 79
+max-line-length = 119
 import-order-style = edited
 docstring-convention = numpy
 exclude = src/roswire/common/cmake.py

--- a/src/roswire/common/__init__.py
+++ b/src/roswire/common/__init__.py
@@ -12,6 +12,7 @@ from .source import (
     CMakeExtractor,
     CMakeInfo,
     CMakeTarget,
+    PackageCMakeTargets,
     SourceLanguage,
 )
 from .srv import SrvFormat

--- a/src/roswire/common/source.py
+++ b/src/roswire/common/source.py
@@ -3,6 +3,7 @@ __all__ = (
     "CMakeInfo",
     "CMakeTarget",
     "CMakeExtractor",
+    "PackageCMakeTargets",
     "SourceLanguage",
 )
 
@@ -55,8 +56,23 @@ class CMakeTarget:
 
 
 @attr.s(auto_attribs=True, slots=True)
-class CMakeBinaryTarget(CMakeTarget):
+class PackageCMakeTargets:
+    """Describes the CMake build targets for a given package
 
+    Attributes
+    ----------
+    package: Package
+        the package to which these sources belong
+    targets: t.Collection[CMakeTarget]
+        the build targets that are contained within this package
+    """
+
+    package: Package
+    targets: t.Collection[CMakeTarget]
+
+
+@attr.s(auto_attribs=True, slots=True)
+class CMakeBinaryTarget(CMakeTarget):
     @property
     def entrypoint(self) -> t.Optional[str]:
         if self.language == SourceLanguage.CXX:
@@ -67,7 +83,6 @@ class CMakeBinaryTarget(CMakeTarget):
 
 @attr.s(auto_attribs=True, slots=True)
 class CMakeLibraryTarget(CMakeBinaryTarget):
-
     _entrypoint: t.Optional[str] = attr.ib(init=False)
 
     @property

--- a/src/roswire/ros1/ros1.py
+++ b/src/roswire/ros1/ros1.py
@@ -440,4 +440,17 @@ class ROS1:
         """Obtains a description of the CMake targets for all packages within
         this application.
         """
-        raise NotImplementedError
+        output: t.List[PackageCMakeTargets] = []
+
+        for package in self.__description.packages.values():
+
+            # ignore any packages without a CMakeLists.txt
+            cmake_filename = os.path.join(package.path, "CMakeLists.txt")
+            if not self.__files.exists(cmake_filename):
+                continue
+
+            target_to_info = self.package_node_sources(package)
+            package_cmake_targets = PackageCMakeTargets(package, target_to_info.values())
+            output.append(package_cmake_targets)
+
+        return output

--- a/src/roswire/ros1/ros1.py
+++ b/src/roswire/ros1/ros1.py
@@ -3,7 +3,7 @@ __all__ = ("ROS1",)
 
 import os
 import time
-import typing
+import typing as t
 import xmlrpc.client
 from types import TracebackType
 from typing import (
@@ -29,13 +29,15 @@ from .. import exceptions as exc
 from ..common import (
     CMakeTarget,
     NodeManager,
-    Package, ROSLaunchManager,
+    Package,
+    PackageCMakeTargets,
+    ROSLaunchManager,
     SystemState,
 )
 from ..exceptions import ROSWireException
 from ..util import is_port_open, Stopwatch, wait_till_open
 
-if typing.TYPE_CHECKING:
+if t.TYPE_CHECKING:
     from .. import AppDescription
 
 
@@ -431,3 +433,11 @@ class ROS1:
         return self.__package_source_extractor.get_cmake_info(
             package
         ).targets
+
+    def cmake_targets_for_all_packages(
+        self
+    ) -> t.Collection[PackageCMakeTargets]:
+        """Obtains a description of the CMake targets for all packages within
+        this application.
+        """
+        raise NotImplementedError


### PR DESCRIPTION
This method is used to simply find the CMake targets across all relevant packages within a given image.